### PR TITLE
Use RetryExecutor when retrying

### DIFF
--- a/src/test/java/org/embulk/input/azure_blob_storage/TestAzureBlobStorageFileInputPlugin.java
+++ b/src/test/java/org/embulk/input/azure_blob_storage/TestAzureBlobStorageFileInputPlugin.java
@@ -90,7 +90,7 @@ public class TestAzureBlobStorageFileInputPlugin
 
         PluginTask task = config.loadConfig(PluginTask.class);
         assertEquals(5000, task.getMaxResults());
-        assertEquals(5, task.getMaxConnectionRetry());
+        assertEquals(10, task.getMaxConnectionRetry());
     }
 
     @Test(expected = ConfigException.class)


### PR DESCRIPTION
Modify retry logic to use `RetryExecutor` that is provied by [embulk-core](https://github.com/embulk/embulk/blob/master/embulk-core/src/main/java/org/embulk/spi/util/RetryExecutor.java)
- `listFilesWithPrefix`
- `SingleFileProvider.openNext()`
