### PR TITLE
Support incremental flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ First, create Azure [Storage Account](https://azure.microsoft.com/en-us/document
 - **account_key**: primary access key (string, required)
 - **container**: container name data stored (string, required)
 - **path_prefix**: prefix of target keys (string, required) (string, required)
+- **incremental**: enables incremental loading(boolean, optional. default: true). If incremental loading is enabled, config diff for the next execution will include `last_path` parameter so that next execution skips files before the path. Otherwise, `last_path` will not be included.
 - **path_match_pattern**: regexp to match file paths. If a file path doesn't match with this pattern, the file will be skipped (regexp string, optional)
 - **total_file_count_limit**: maximum number of files to read (integer, optional)
 

--- a/src/main/java/org/embulk/input/azure_blob_storage/AzureBlobStorageFileInputPlugin.java
+++ b/src/main/java/org/embulk/input/azure_blob_storage/AzureBlobStorageFileInputPlugin.java
@@ -57,6 +57,10 @@ public class AzureBlobStorageFileInputPlugin
         @Config("path_prefix")
         String getPathPrefix();
 
+        @Config("incremental")
+        @ConfigDefault("true")
+        boolean getIncremental();
+
         @Config("last_path")
         @ConfigDefault("null")
         Optional<String> getLastPath();
@@ -95,7 +99,9 @@ public class AzureBlobStorageFileInputPlugin
         control.run(taskSource, taskCount);
 
         ConfigDiff configDiff = Exec.newConfigDiff();
-        configDiff.set("last_path", task.getFiles().getLastPath(task.getLastPath()));
+        if (task.getIncremental()) {
+            configDiff.set("last_path", task.getFiles().getLastPath(task.getLastPath()));
+        }
 
         return configDiff;
     }


### PR DESCRIPTION
In this PR, I added `incremental` option. This option was already implemented at [embulk-input-s3](https://github.com/embulk/embulk-input-s3/) and [embulk-input-gcs](https://github.com/embulk/embulk-input-gcs/) works same.

We have a system that automates incremental data loading.
But some use cases don't need incremental data loading.

Instead, they load the entire data every time and replaces the data in the destination table every time. This flag controls the behavior.
