### PR TITLE
Enhance incremental

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,7 @@
 language: java
 
+dist: trusty
+
 jdk:
   - oraclejdk8
 

--- a/src/main/java/org/embulk/input/azure_blob_storage/AzureBlobStorageFileInputPlugin.java
+++ b/src/main/java/org/embulk/input/azure_blob_storage/AzureBlobStorageFileInputPlugin.java
@@ -82,6 +82,8 @@ public class AzureBlobStorageFileInputPlugin
 
     private static final Logger log = Exec.getLogger(AzureBlobStorageFileInputPlugin.class);
 
+    private static boolean IS_REMOVE_FIRST_RECORD = true;
+
     @Override
     public ConfigDiff transaction(ConfigSource config, FileInputPlugin.Control control)
     {
@@ -167,6 +169,10 @@ public class AzureBlobStorageFileInputPlugin
                             do {
                                 blobs = container.listBlobsSegmented(prefix, true, null, maxResults, token, null, null);
                                 log.debug(String.format("result count(include directory):%s continuationToken:%s", blobs.getLength(), blobs.getContinuationToken()));
+                                if (lastKey != null && !blobs.getResults().isEmpty() && IS_REMOVE_FIRST_RECORD) {
+                                    log.info("Remove first item " + blobs.getResults().remove(0).getStorageUri().getPrimaryUri());
+                                    IS_REMOVE_FIRST_RECORD = false;
+                                }
                                 for (ListBlobItem blobItem : blobs.getResults()) {
                                     if (blobItem instanceof CloudBlob) {
                                         CloudBlob blob = (CloudBlob) blobItem;

--- a/src/test/java/org/embulk/input/azure_blob_storage/TestAzureBlobStorageFileInputPlugin.java
+++ b/src/test/java/org/embulk/input/azure_blob_storage/TestAzureBlobStorageFileInputPlugin.java
@@ -223,8 +223,11 @@ public class TestAzureBlobStorageFileInputPlugin
 
         assertRecords(config, output);
 
+        output.pages.clear();
+
         config.set("last_path", configDiff.get(String.class, "last_path"));
         task = config.loadConfig(PluginTask.class);
+        runner.transaction(config, new Control());
         task.setFiles((FileList) listFiles.invoke(plugin, task));
         List<Object[]> records = getRecords(config, output);
         assertEquals(0, records.size());

--- a/src/test/java/org/embulk/input/azure_blob_storage/TestAzureBlobStorageFileInputPlugin.java
+++ b/src/test/java/org/embulk/input/azure_blob_storage/TestAzureBlobStorageFileInputPlugin.java
@@ -211,6 +211,26 @@ public class TestAzureBlobStorageFileInputPlugin
     }
 
     @Test
+    public void testAzureIncrementalWithoutDuplicate()
+            throws NoSuchMethodException, IllegalAccessException, InvocationTargetException, IOException
+    {
+        PluginTask task = config.loadConfig(PluginTask.class);
+        ConfigDiff configDiff = runner.transaction(config, new Control());
+
+        Method listFiles = AzureBlobStorageFileInputPlugin.class.getDeclaredMethod("listFiles", PluginTask.class);
+        listFiles.setAccessible(true);
+        task.setFiles((FileList) listFiles.invoke(plugin, task));
+
+        assertRecords(config, output);
+
+        config.set("last_path", configDiff.get(String.class, "last_path"));
+        task = config.loadConfig(PluginTask.class);
+        task.setFiles((FileList) listFiles.invoke(plugin, task));
+        List<Object[]> records = getRecords(config, output);
+        assertEquals(0, records.size());
+    }
+
+    @Test
     public void testCreateNextToken() throws Exception
     {
         Method base64Encode = AzureBlobStorageFileInputPlugin.class.getDeclaredMethod("createNextToken", String.class);


### PR DESCRIPTION
We should enhance incremental run to skip the file in `last_path` params to avoid duplicated in the next time runs. 
That introduces logic changes when we list files.